### PR TITLE
Feat:  Implement the foundation of the game

### DIFF
--- a/Kapuro-2024-Spring/Assets/PlayFabEditorExtensions.meta
+++ b/Kapuro-2024-Spring/Assets/PlayFabEditorExtensions.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e6b6b62449f1f4ed1bdf033d7f2d2ccf
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Kapuro-2024-Spring/Assets/PlayFabEditorExtensions/Editor.meta
+++ b/Kapuro-2024-Spring/Assets/PlayFabEditorExtensions/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c897fef01cc7d7d4a84f9f114b5133c6
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Kapuro-2024-Spring/Assets/PlayFabEditorExtensions/Editor/Resources.meta
+++ b/Kapuro-2024-Spring/Assets/PlayFabEditorExtensions/Editor/Resources.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b5f845e2a28cb46429c8d80455086ca1
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Kapuro-2024-Spring/Assets/PlayFabEditorExtensions/Editor/Resources/MostRecentPackage.unitypackage.meta
+++ b/Kapuro-2024-Spring/Assets/PlayFabEditorExtensions/Editor/Resources/MostRecentPackage.unitypackage.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 2f6dbc0f9e7498e418262cc45e8b3d46
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Kapuro-2024-Spring/Assets/Resources/Scripts/koto/BrokenRoofTile.cs
+++ b/Kapuro-2024-Spring/Assets/Resources/Scripts/koto/BrokenRoofTile.cs
@@ -5,5 +5,13 @@ using UnityEngine;
 //壊れた瓦
 public class BrokenRoofTile : RoofTile
 {
-    
+    public override RoofTileType roofTileType => RoofTileType.BROKEN; // roofTileType プロパティをオーバーライド
+    public override EvaluateType evaluateType { get; set; } // evaluateType プロパティをオーバーライド
+
+    private int scoreBrokenRoofTile = 50; //スコア
+    public override int Score //スコアのプロパティ
+    {
+        get => scoreBrokenRoofTile;
+        set => scoreBrokenRoofTile = value;
+    }
 }

--- a/Kapuro-2024-Spring/Assets/Resources/Scripts/koto/CorrectRoofTile.cs
+++ b/Kapuro-2024-Spring/Assets/Resources/Scripts/koto/CorrectRoofTile.cs
@@ -4,5 +4,13 @@ using System.Collections.Generic;
 //普通の瓦
 public class CorrectRoofTile : RoofTile
 {
-    
+    public override RoofTileType roofTileType => RoofTileType.NORMAL; // roofTileType プロパティをオーバーライド
+    public override EvaluateType evaluateType { get; set; } // evaluateType プロパティをオーバーライド
+
+    private int scoreCorrectRoofTile = 100; //スコア
+    public override int Score //スコアのプロパティ
+    {
+        get => scoreCorrectRoofTile;
+        set => scoreCorrectRoofTile = value;
+    }
 }

--- a/Kapuro-2024-Spring/Assets/Resources/Scripts/koto/GameControllerKoto.cs
+++ b/Kapuro-2024-Spring/Assets/Resources/Scripts/koto/GameControllerKoto.cs
@@ -5,6 +5,7 @@ using UnityEngine;
 public class GameControllerKoto : AbstractGameController
 {
     [SerializeField] private RoofTileController roofTileController;
+    [SerializeField] private UIControllerKoto uiControllerKoto;
     private void Awake()
     {
         
@@ -17,6 +18,9 @@ public class GameControllerKoto : AbstractGameController
 
     private void Update()
     {
-        
+        roofTileController.Evaluate(); //瓦の評価
+        roofTileController.Destroy(); //瓦の破棄
+        roofTileController.GameEndProcess(); //ゲーム終了時の処理
+        uiControllerKoto.UpdateScoreText(); //スコアの更新
     }
 }

--- a/Kapuro-2024-Spring/Assets/Resources/Scripts/koto/RoofTile.cs
+++ b/Kapuro-2024-Spring/Assets/Resources/Scripts/koto/RoofTile.cs
@@ -5,5 +5,26 @@ using UnityEngine;
 //瓦の抽象クラス
 public abstract class RoofTile : MonoBehaviour
 {
+    public enum RoofTileType
+    {
+        NORMAL,
+        BROKEN
+    }
+
+    public enum EvaluateType
+    {
+        CORRECT,
+        INCORRECT,
+        NOT_EVALUATED,
+    }
     
+    public abstract RoofTileType roofTileType { get; } // RoofTileType を抽象プロパティとして宣言
+    public abstract EvaluateType evaluateType { get; set; } // EvaluateType を抽象プロパティとして宣言
+
+    private int score = 0;
+    public abstract int Score
+    {
+        get;
+        set;
+    }
 }

--- a/Kapuro-2024-Spring/Assets/Resources/Scripts/koto/RoofTileController.cs
+++ b/Kapuro-2024-Spring/Assets/Resources/Scripts/koto/RoofTileController.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using UnityEditor.SceneManagement;
 using UnityEngine;
 
 //RoofTileに関連する処理を行うクラス
@@ -9,11 +10,63 @@ public class RoofTileController : MonoBehaviour
     
     [SerializeField] private RoofTileGenerator roofTileGenerator;
     [SerializeField] private RoofTileDisplayer roofTileDisplayer;
+    [SerializeField] private RoofTileEvaluater roofTileEvaluater;
+    [SerializeField] private RoofTileDestroyer roofTileDestroyer;
+    [SerializeField] private ScoreController scoreController;
     
+    //初期化処理
     public void Initialize()
     {
         roofTileGenerator.Initialize();
         roofTileDisplayer.HideRoofTile();
         roofTileDisplayer.SetRoofTile();
+    }
+
+    //瓦を生成する
+    public void Evaluate()
+    {
+        roofTileEvaluater.EvaluateRoofTile(GetCurrentRoofTile());
+    }
+
+    //瓦を破棄する
+    public void Destroy()
+    {
+        bool isSetNext = roofTileDestroyer.DestroyEvaluatedRoofTile(GetCurrentRoofTile());
+
+        if (isSetNext == true)
+        {
+            SetNewRoofTile();
+        }
+    }
+
+    //新しく瓦をセットする
+    private void SetNewRoofTile()
+    {
+        roofTileDisplayer.SetRoofTile();
+        roofTileDisplayer.ActivateRoofTile();
+        roofTileDisplayer.HideRoofTile();
+    }
+
+    //ゲーム終了時の処理
+    public void GameEndProcess()
+    {
+        //TODO: ゲーム終了時の処理を追加
+        if (roofTiles.Count == 0)
+        {
+            SceneController.ChangeSceneToTitle();
+        }
+    }
+    
+    //現在の瓦を取得する
+    private GameObject GetCurrentRoofTile()
+    {
+        if (roofTiles.Count != 0)
+        {
+            return roofTiles[0];
+        }
+        else //最後の瓦の場合
+        {
+            return null;
+        }
     }
 }

--- a/Kapuro-2024-Spring/Assets/Resources/Scripts/koto/RoofTileDestroyer.cs
+++ b/Kapuro-2024-Spring/Assets/Resources/Scripts/koto/RoofTileDestroyer.cs
@@ -1,0 +1,36 @@
+using System.Collections;
+using System.Collections.Generic;
+using Cysharp.Threading.Tasks.Triggers;
+using UnityEngine;
+
+public class RoofTileDestroyer : MonoBehaviour
+{
+    [SerializeField] private RoofTileController roofTileController;
+    
+    //瓦を破棄する
+    public bool DestroyEvaluatedRoofTile(GameObject roofTile)
+    {
+        if (roofTile != null)
+        {
+            switch (roofTile.GetComponent<RoofTile>().evaluateType)
+            {
+                case RoofTile.EvaluateType.CORRECT: //瓦が正解の場合
+                    //ここに破棄時の処理を追加
+                    roofTileController.roofTiles.Remove(roofTile);
+                    Destroy(roofTile);
+                    return true; //次の瓦をセットするためのフラグ
+                case RoofTile.EvaluateType.INCORRECT: //瓦が不正解の場合
+                    //ここに破棄時の処理を追加
+                    roofTileController.roofTiles.Remove(roofTile);
+                    Destroy(roofTile);
+                    return true; //次の瓦をセットするためのフラグ
+                case RoofTile.EvaluateType.NOT_EVALUATED: //瓦が評価されていない場合
+                    return false;
+                default:
+                    return false;
+            }
+        }
+
+        return false;
+    }
+}

--- a/Kapuro-2024-Spring/Assets/Resources/Scripts/koto/RoofTileDestroyer.cs.meta
+++ b/Kapuro-2024-Spring/Assets/Resources/Scripts/koto/RoofTileDestroyer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e96e025f2bb801a4184437e57db6c7e1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Kapuro-2024-Spring/Assets/Resources/Scripts/koto/RoofTileDisplayer.cs
+++ b/Kapuro-2024-Spring/Assets/Resources/Scripts/koto/RoofTileDisplayer.cs
@@ -9,10 +9,18 @@ public class RoofTileDisplayer : MonoBehaviour
     //1番目と2番目の瓦をセット
     public void SetRoofTile()
     {
-        roofTileController.roofTiles[0].transform.localPosition = new Vector3(-550, -400, 0);
-        roofTileController.roofTiles[0].transform.localScale = new Vector3(50, 50, 0);
-        roofTileController.roofTiles[1].transform.localPosition = new Vector3(0, -400, 0);
-        roofTileController.roofTiles[1].transform.localScale = new Vector3(50, 50, 0);
+        if (roofTileController.roofTiles.Count >= 2)
+        {
+            roofTileController.roofTiles[0].transform.localPosition = new Vector3(0, -400, 0);
+            roofTileController.roofTiles[0].transform.localScale = new Vector3(50, 50, 0);
+            roofTileController.roofTiles[1].transform.localPosition = new Vector3(0, 0, 0);
+            roofTileController.roofTiles[1].transform.localScale = new Vector3(50, 50, 0);
+        }
+        else if(roofTileController.roofTiles.Count != 0) //最後の瓦の場合
+        {
+            roofTileController.roofTiles[0].transform.localPosition = new Vector3(0, -400, 0);
+            roofTileController.roofTiles[0].transform.localScale = new Vector3(50, 50, 0);
+        }
     }
     
     //３番目以下の瓦を消す
@@ -22,5 +30,12 @@ public class RoofTileDisplayer : MonoBehaviour
         {
             roofTileController.roofTiles[i].gameObject.SetActive(false);
         }
+    }
+
+    //２番目の瓦を表示
+    public void ActivateRoofTile()
+    {
+        if(roofTileController.roofTiles.Count >= 2)
+            roofTileController.roofTiles[1].gameObject.SetActive(true);
     }
 }

--- a/Kapuro-2024-Spring/Assets/Resources/Scripts/koto/RoofTileEvaluater.cs
+++ b/Kapuro-2024-Spring/Assets/Resources/Scripts/koto/RoofTileEvaluater.cs
@@ -1,0 +1,71 @@
+using System.Collections;
+using System.Collections.Generic;
+using Cysharp.Threading.Tasks;
+using Unity.VisualScripting;
+using UnityEngine;
+
+//RoofTileが正しく仕訳けられたか評価するクラス
+public class RoofTileEvaluater : MonoBehaviour
+{
+    [SerializeField] private ScoreController scoreController; //スコアを管理するクラス
+    [SerializeField] private RoofTileController roofTileController; //瓦を管理するクラス
+
+    //瓦の評価を行う
+    public void EvaluateRoofTile(GameObject currentRoofTile)
+    {
+        if (currentRoofTile != null)
+        {
+            //瓦を置く
+            if(Input.GetKeyDown(KeyCode.RightArrow) == true)
+            {
+                switch (currentRoofTile.GetComponent<RoofTile>().roofTileType)
+                {
+                    case RoofTile.RoofTileType.NORMAL: //瓦が普通の場合
+                        SendCorrect();
+                        scoreController.AddScore(currentRoofTile.GetComponent<RoofTile>().Score); //スコアを加算
+                        currentRoofTile.GetComponent<RoofTile>().evaluateType = RoofTile.EvaluateType.INCORRECT; //評価を不正解にする
+                        break;
+                    case RoofTile.RoofTileType.BROKEN: //瓦が壊れている場合
+                        SendIncorrect();
+                        currentRoofTile.GetComponent<RoofTile>().evaluateType = RoofTile.EvaluateType.CORRECT; //評価を正解にする
+                        break;
+                    default:
+                        break;
+                }
+            }
+
+            //瓦を捨てる
+            if (Input.GetKeyDown(KeyCode.LeftArrow) == true)
+            {
+                switch (currentRoofTile.GetComponent<RoofTile>().roofTileType)
+                {
+                    case RoofTile.RoofTileType.NORMAL: //瓦が普通の場合
+                        SendIncorrect();
+                        currentRoofTile.GetComponent<RoofTile>().evaluateType = RoofTile.EvaluateType.CORRECT; //評価を正解にする
+                        break;
+                    case RoofTile.RoofTileType.BROKEN: //瓦が壊れている場合
+                        SendCorrect();
+                        scoreController.AddScore(currentRoofTile.GetComponent<RoofTile>().Score); //スコアを加算
+                        currentRoofTile.GetComponent<RoofTile>().evaluateType = RoofTile.EvaluateType.INCORRECT; //評価を不正解にする
+                        break;
+                    default:
+                        break;
+                }
+            }
+        }
+    }
+    
+    //DEBUG
+    //正解時の処理
+    private void SendCorrect()
+    {
+        Debug.Log("正解");
+    }
+    
+    //DEBUG
+    //不正解時の処理
+    private void SendIncorrect()
+    {
+        Debug.Log("不正解");
+    }
+}

--- a/Kapuro-2024-Spring/Assets/Resources/Scripts/koto/RoofTileEvaluater.cs.meta
+++ b/Kapuro-2024-Spring/Assets/Resources/Scripts/koto/RoofTileEvaluater.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8efca7fbf19253543935536fac8ec099
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Kapuro-2024-Spring/Assets/Resources/Scripts/koto/RoofTileGenerator.cs
+++ b/Kapuro-2024-Spring/Assets/Resources/Scripts/koto/RoofTileGenerator.cs
@@ -39,11 +39,13 @@ public class RoofTileGenerator : MonoBehaviour
             case 0: //CorrectRoofTileを生成
                 prefabController.InstantiatePrefab("CorrectRoofTile", Vector3.zero, Quaternion.identity, addGameObjectController.NewGameObject); //PrefabからCorrectRoofTileを複製
                 GameObject correctRoofTile = prefabController.clonePrefab;
+                correctRoofTile.GetComponent<RoofTile>().evaluateType = RoofTile.EvaluateType.NOT_EVALUATED; //CorrectRoofTileの評価をNOT_EVALUATEDに設定
                 roofTileController.roofTiles.Add(correctRoofTile); //複製したCorrectRoofTileをリストに追加
                 break;
             case 1: //BrokenRoofTileを生成
                 prefabController.InstantiatePrefab("BrokenRoofTile", Vector3.zero, Quaternion.identity, addGameObjectController.NewGameObject); //PrefabからBrokenRoofTileを複製
                 GameObject brokenRoofTile = prefabController.clonePrefab;
+                brokenRoofTile.GetComponent<RoofTile>().evaluateType = RoofTile.EvaluateType.NOT_EVALUATED; //BrokenRoofTileの評価をNOT_EVALUATEDに設定
                 roofTileController.roofTiles.Add(brokenRoofTile); //複製したBrokenRoofTileをリストに追加
                 break;
             default:

--- a/Kapuro-2024-Spring/Assets/Resources/Scripts/koto/ScoreController.cs
+++ b/Kapuro-2024-Spring/Assets/Resources/Scripts/koto/ScoreController.cs
@@ -1,0 +1,21 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class ScoreController : MonoBehaviour
+{
+    [SerializeField] private int accumulatedScore; //スコアの合計値
+
+    public int AccumulatedScore
+    {
+        get => accumulatedScore;
+        set => accumulatedScore = value;
+    }
+    
+    
+    //スコアを加算する
+    public void AddScore(int score)
+    {
+        accumulatedScore += score;
+    }
+}

--- a/Kapuro-2024-Spring/Assets/Resources/Scripts/koto/ScoreController.cs.meta
+++ b/Kapuro-2024-Spring/Assets/Resources/Scripts/koto/ScoreController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1a3615cb07523b14a9f8e10321e35f87
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Kapuro-2024-Spring/Assets/Resources/Scripts/koto/UIControllerKoto.cs
+++ b/Kapuro-2024-Spring/Assets/Resources/Scripts/koto/UIControllerKoto.cs
@@ -1,0 +1,16 @@
+using System.Collections;
+using System.Collections.Generic;
+using TMPro;
+using UnityEngine;
+
+public class UIControllerKoto : MonoBehaviour
+{
+    [SerializeField] private ScoreController scoreController;
+
+    [SerializeField] private TextMeshProUGUI scoreText;
+
+    public void UpdateScoreText()
+    {
+        scoreText.text = "Score: " + scoreController.AccumulatedScore;
+    }
+}

--- a/Kapuro-2024-Spring/Assets/Resources/Scripts/koto/UIControllerKoto.cs.meta
+++ b/Kapuro-2024-Spring/Assets/Resources/Scripts/koto/UIControllerKoto.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 48fdb787f05e8c247aaaecb561b86a60
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Kapuro-2024-Spring/Assets/Scenes/Title.unity
+++ b/Kapuro-2024-Spring/Assets/Scenes/Title.unity
@@ -1731,7 +1731,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 1771980031}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f694ba6fdc031164b970809494041dd7, type: 3}
+  m_Script: {fileID: 11500000, guid: 04e62dda0a85bc74ebeb28043c8b826a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   buttonScene01: {fileID: 341151724}

--- a/Kapuro-2024-Spring/Assets/Scenes/koto.unity
+++ b/Kapuro-2024-Spring/Assets/Scenes/koto.unity
@@ -265,7 +265,7 @@ Transform:
   m_GameObject: {fileID: 306466174}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -550, y: -400, z: 0}
+  m_LocalPosition: {x: 0, y: -400, z: 0}
   m_LocalScale: {x: 50, y: 50, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -323,6 +323,51 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
+--- !u!1 &319551221
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 319551222}
+  - component: {fileID: 319551223}
+  m_Layer: 0
+  m_Name: ScoreController
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &319551222
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 319551221}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 330607404}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &319551223
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 319551221}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1a3615cb07523b14a9f8e10321e35f87, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  accumulatedScore: 0
 --- !u!1 &330607403
 GameObject:
   m_ObjectHideFlags: 0
@@ -355,6 +400,9 @@ Transform:
   m_Children:
   - {fileID: 196959743}
   - {fileID: 1081099112}
+  - {fileID: 948854493}
+  - {fileID: 2027192202}
+  - {fileID: 319551222}
   m_Father: {fileID: 812616115}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &330607405
@@ -370,9 +418,58 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   roofTiles: []
-  allRoofTileNum: 5
+  allRoofTileNum: 30
   roofTileGenerator: {fileID: 196959744}
   roofTileDisplayer: {fileID: 1081099113}
+  roofTileEvaluater: {fileID: 948854494}
+  roofTileDestroyer: {fileID: 2027192203}
+  scoreController: {fileID: 319551223}
+--- !u!1 &353453844
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 353453845}
+  - component: {fileID: 353453846}
+  m_Layer: 0
+  m_Name: UIControllerKoto
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &353453845
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 353453844}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 812616115}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &353453846
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 353453844}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 48fdb787f05e8c247aaaecb561b86a60, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  scoreController: {fileID: 319551223}
+  scoreText: {fileID: 1481926655}
 --- !u!1 &357088584
 GameObject:
   m_ObjectHideFlags: 0
@@ -472,6 +569,7 @@ Transform:
   m_Children:
   - {fileID: 1821369920}
   - {fileID: 306466175}
+  - {fileID: 1567238720}
   m_Father: {fileID: 1033568989}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &644044492
@@ -641,11 +739,192 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
+  - {fileID: 353453845}
   - {fileID: 644044493}
   - {fileID: 1527553599}
   - {fileID: 330607404}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &932356886
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 932356887}
+  - component: {fileID: 932356889}
+  - component: {fileID: 932356888}
+  m_Layer: 0
+  m_Name: RightArrow
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &932356887
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 932356886}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1562371330}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 350, y: -200}
+  m_SizeDelta: {x: 200, y: 50}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &932356888
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 932356886}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Correct ->
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4278190080
+  m_fontColor: {r: 0, g: 0, b: 0, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 36
+  m_fontSizeBase: 36
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 256
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &932356889
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 932356886}
+  m_CullTransparentMesh: 1
+--- !u!1 &948854492
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 948854493}
+  - component: {fileID: 948854494}
+  m_Layer: 0
+  m_Name: RoofTileEvaluater
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &948854493
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 948854492}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0.40618056, y: 0.2739123, z: -9.93418}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 330607404}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &948854494
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 948854492}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8efca7fbf19253543935536fac8ec099, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  scoreController: {fileID: 319551223}
+  roofTileController: {fileID: 330607405}
 --- !u!1 &1033568988
 GameObject:
   m_ObjectHideFlags: 0
@@ -796,6 +1075,140 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   roofTileController: {fileID: 330607405}
   roofTileGenerator: {fileID: 196959744}
+--- !u!1 &1191179608
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1191179609}
+  - component: {fileID: 1191179611}
+  - component: {fileID: 1191179610}
+  m_Layer: 0
+  m_Name: LeftArrow
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1191179609
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1191179608}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1562371330}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -350, y: -200}
+  m_SizeDelta: {x: 200, y: 50}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1191179610
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1191179608}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: <- InCorrect
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4278190080
+  m_fontColor: {r: 0, g: 0, b: 0, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 36
+  m_fontSizeBase: 36
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 256
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &1191179611
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1191179608}
+  m_CullTransparentMesh: 1
 --- !u!1 &1252469437
 GameObject:
   m_ObjectHideFlags: 0
@@ -845,6 +1258,141 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   roofTileController: {fileID: 330607405}
+  uiControllerKoto: {fileID: 353453846}
+--- !u!1 &1481926653
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1481926654}
+  - component: {fileID: 1481926656}
+  - component: {fileID: 1481926655}
+  m_Layer: 0
+  m_Name: ScoreText
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1481926654
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1481926653}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1562371330}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -500, y: 300}
+  m_SizeDelta: {x: 500, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1481926655
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1481926653}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Score is here
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4278848010
+  m_fontColor: {r: 0.03773582, g: 0.03773582, b: 0.03773582, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 80
+  m_fontSizeBase: 80
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &1481926656
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1481926653}
+  m_CullTransparentMesh: 1
 --- !u!1 &1527553598
 GameObject:
   m_ObjectHideFlags: 0
@@ -916,7 +1464,10 @@ RectTransform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
-  m_Children: []
+  m_Children:
+  - {fileID: 1191179609}
+  - {fileID: 932356887}
+  - {fileID: 1481926654}
   m_Father: {fileID: 1033568989}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
@@ -924,6 +1475,90 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &1567238719
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1567238720}
+  - component: {fileID: 1567238721}
+  m_Layer: 0
+  m_Name: Point2
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1567238720
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1567238719}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 50, y: 50, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 521067474}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &1567238721
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1567238719}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: -2413806693520163455, guid: a86470a33a6bf42c4b3595704624658b, type: 3}
+  m_Color: {r: 0, g: 0, b: 0, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
 --- !u!1 &1821369919
 GameObject:
   m_ObjectHideFlags: 0
@@ -1039,6 +1674,51 @@ Transform:
   m_Children: []
   m_Father: {fileID: 1252469438}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &2027192201
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2027192202}
+  - component: {fileID: 2027192203}
+  m_Layer: 0
+  m_Name: RoofTileDestroyer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2027192202
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2027192201}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 330607404}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &2027192203
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2027192201}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e96e025f2bb801a4184437e57db6c7e1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  roofTileController: {fileID: 330607405}
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
各種RoofTileを変更に合わせて修正
RoofTileDestroyerを追加
RoofTileEvaluaterを追加
ScoreControllerを追加
UIControllerを追加

とりあえず、ゲームとしての基盤が完成。
初めから終わりまで、ゲームをプレイできます。
左右矢印キーで瓦を仕分けられます。
RoofTileControllerのヒエラルキーウィンドウで生成する瓦の数を決められます。